### PR TITLE
Wordselect does not need to require jquery on the page

### DIFF
--- a/questiontype.php
+++ b/questiontype.php
@@ -44,17 +44,6 @@ class qtype_wordselect extends question_type {
     }
 
     /**
-     * Utility method used by {@link qtype_renderer::head_code()}
-     * It looks for any of the files script.js or script.php that
-     * exist in the plugin folder and ensures they get included.
-     * It also includes the jquery files required for this plugin
-     */
-    public function find_standard_scripts() {
-        global $PAGE;
-        parent::find_standard_scripts();
-        $PAGE->requires->jquery();
-    }
-    /**
      * Move all the files belonging to this question from one context to another.
      * @param int $questionid the question being moved.
      * @param int $oldcontextid the context it is moving from.


### PR DESCRIPTION
Hi Marcus,
The function find_standard_scripts() in questiontype.php calling the parent and $PAGE->requires->jquery() afterward. This causing an issue as you can see on attachment in filter/embedquestion plugin. I have deleted this method, since the parent method doing the job and there is no need to require jquery agin. I think this is not needed anymore, since the  selection.js was transferred to amd/src...

![wordselect_jquery_issue](https://user-images.githubusercontent.com/391771/67943291-a8308700-fbd1-11e9-9784-08461f79f12a.PNG)

