### PR TITLE
WordSelect: Spacing issue on row with punctuation

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -33,7 +33,7 @@
     background-origin: padding-box;
     background-size: auto auto;
     border: solid thin black;
-    margin: 0;
+    margin: 0 3px 0 3px;
     display: inline;
     white-space: nowrap;
     -moz-box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.9);


### PR DESCRIPTION
Hi Marcus,
Happy New Year!

An issue has been reported with spacing when a word is adjacent with punctuation.

![qtype_WS_spacing1](https://user-images.githubusercontent.com/391771/72430813-2ccf8200-378b-11ea-86b6-c909e269c9b5.PNG)
qtype_WS_spacing1

![qtype_WS_spacing2](https://user-images.githubusercontent.com/391771/72430819-31943600-378b-11ea-8dca-2d51a0f9f9d5.PNG)
qtype_WS_spacing2

![qtype_WS_spacing3](https://user-images.githubusercontent.com/391771/72430825-3527bd00-378b-11ea-821b-f5104c22f74d.PNG)
qtype_WS_spacing3

As you see from the screenshots (qtype_WS_spacing2) the '**,**' after the word '**corner**' and the '**;**' after the word '**pie**' are barely visible.
I have just add a css margin to '.que.wordselect .selected' class. It looks better, however, I think we might need a better solution. For instance, in Spanish they use punctuation at the start and also middle of a sentence  (such as inverted question and exclamation marks).
In other words, we need some sort of logic that the margin-left or margin-right is used conditionally in context when a selectable word is adjacent with punctuation (left or right of the word without a white-space). Also, some question author may create questions where only punctuation are the selectable item. In this case the selected punctuation will overlap the adjacent word. 
   

