### PR TITLE
Make CSS rules safer

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,8 +1,8 @@
-.que.wordselect input[type=checkbox] {
+.que.wordselect .qtext input[type=checkbox] {
     display: none;
 }
 
-.que.wordselect .selectable {
+.que.wordselect .qtext .selectable {
     background-attachment: scroll;
     background-clip: border-box;
     background-image: none;
@@ -16,13 +16,12 @@
     white-space: nowrap;
 }
 
-.que.wordselect .multiword {
+.que.wordselect .qtext .multiword {
     border: thin solid black;
     border-radius: 0.25em;
 }
 
-.que.wordselect .selected {
-    background: #cee0f4;
+.que.wordselect .qtext .selected {
     border-radius: 0.25em;
     background-color: #cbcfd4;
     background-image: none;
@@ -43,12 +42,12 @@
     outline-width: thin;
 }
 
-.que.wordselect .keyboard_focus {
+.que.wordselect .qtext .keyboard_focus {
     border-color: #0a0;
     box-shadow: 0 0 5px 5px rgba(255, 255, 150, 1);
 }
 
-.que.wordselect .incorrect {
+.que.wordselect .qtext .incorrect {
     background-attachment: scroll;
     background-color: #f7d0d0;
     background-image: none;
@@ -69,7 +68,7 @@
 }
 
 /* correct answer if not selected */
-.que.wordselect .correct {
+.que.wordselect .qtext .correct {
     background-color: #ee2;
     border-radius: 0.25em;
     background-clip: border-box;
@@ -79,7 +78,7 @@
     white-space: nowrap;
 }
 
-.que.wordselect .correctresponse {
+.que.wordselect .qtext .correctresponse {
     background: #9dd8bb;
     border-radius: 0.25em;
     background-image: none;


### PR DESCRIPTION
This is probably only a theoretical problem for these CSS rules, but in overriding this CSS in our custom theme, someone was inspired to write the rule

.que.wordselect span {
    margin-left: -3px
}

which applies much too broadly, and so broke other parts of the question layout.

As far as I can see (but correctly me if I am wrong), these CSS rules only need to apply within the .qtext div, so it is much safer to include that in the selector. What do you think?