### PR TITLE
Styling lost in read-only paragraph mode if the Whether correct option is off

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -104,17 +104,14 @@ class qtype_wordselect_renderer extends qtype_with_combined_feedback_renderer {
             }
             if ($options->readonly) {
                 $wordattributes['tabindex'] = '';
-                if ($iscorrectplace && ($isselected == true)) {
-                    $wordattributes['class'] = 'readonly correctresponse';
+                $class = ['readonly'];
+                if ($question->multiword) {
+                    $class[] = 'multiword';
                 }
-
-                if (!($iscorrectplace)) {
-                    if ($isselected == true) {
-                        $wordattributes['class'] = 'readonly incorrect ';
-                    } else if (($question->multiword == true)) {
-                        $wordattributes['class'] = 'readonly multiword ';
-                    }
+                if ($isselected) {
+                    $class[] = $iscorrectplace ? 'correctresponse' : 'incorrect';
                 }
+                $wordattributes['class'] = implode(' ', $class);
             } else {
                 $qasdata = $qa->get_last_qt_var($question->field($place));
                 /* when scrolling back and forth between questions


### PR DESCRIPTION
Hi @marcusgreen,
I found a bug related to the paragraph mode.
 Steps to replicate

1. Create Wordselect question
2. Preview it
3. Change Whether correct option to off in the Display option
4. Press Submit and Finish button

Observer the correct answer

Thanks, 