### PR TITLE
Skip multilang2 test if that filter is not installed

### DIFF
--- a/tests/behat/filter_test.feature
+++ b/tests/behat/filter_test.feature
@@ -1,7 +1,8 @@
 @core @qtype @qtype_wordselect @qtype_wordselect_mlang @_switch_window
 Feature: Test the mlang and mlang2 filters work with qtype_wordselect
   Background:
-    Given the following "users" exist:
+    Given the filter_multilang2 plugin is installed
+    And the following "users" exist:
         | username | firstname | lastname | email               |
         | teacher1 | T1        | Teacher1 | teacher1@moodle.com |
     And the following "courses" exist:


### PR DESCRIPTION
Hi Marcus.

Once https://tracker.moodle.org/browse/MDL-74636 is merged into core, I think this is the sort of change you should make. (But, until that is merged, the tests here will fail - or actually, it might not because of https://github.com/moodlehq/moodle-plugin-ci/issues/164.)