### PR TITLE
Fix Behat tests for mlang and mlang2 filters

### DIFF
--- a/tests/behat/filter_test.feature
+++ b/tests/behat/filter_test.feature
@@ -1,4 +1,4 @@
-@core @qtype @qtype_wordselect @qtype_wordselect_mlang @_switch_window
+@core @qtype @qtype_wordselect @qtype_wordselect_mlang
 Feature: Test the mlang and mlang2 filters work with qtype_wordselect
   Background:
     Given the following "users" exist:
@@ -15,7 +15,8 @@ Feature: Test the mlang and mlang2 filters work with qtype_wordselect
 
   @javascript
   Scenario: Create a question and check mlang2 works as expected
-    When I am on the "Course 1" "core_question > course question bank" page logged in as teacher1
+    When the filter_multilang2 plugin is installed
+    And I am on the "Course 1" "core_question > course question bank" page logged in as teacher1
 
   # Create a new question with mlang2 tags
   # Then check that the french words are not displayed
@@ -26,7 +27,7 @@ Feature: Test the mlang and mlang2 filters work with qtype_wordselect
     Then I should see "Word-Select-001"
 
   # Preview it.
-    When I am on the "Word-Select-001" "core_question > preview" page
+    And I am on the "Word-Select-001" "core_question > preview" page
     And I should see "two"
     And I should see "one"
     And I should see "selection"
@@ -39,22 +40,17 @@ Feature: Test the mlang and mlang2 filters work with qtype_wordselect
     And I should see "Mark 2.00 out of 2.00"
     And I should see "Your answer is correct"
 
-  # This is supposed to test the core mlang filter, however I cannot get that filter to work
-  # at all under any circumstance
-  # @javascript
-  # Scenario: Create a question and check (core) mlang works as expected
-  #   Given I log in as "teacher1"
-  #   And I am on "Course 1" course homepage
-  #   And I navigate to "Questions" in current page administration
-  #   And I add a "Word Select" question filling the form with:
-  #       | Question name | Word-Select-002                                                 |
-  #       | Introduction  | <span lang="fr" class="multilang">deaux</span> two              |
-  #       | Question text | [correct] <span lang="fr" class="multilang">trois</span> [word] |
-  #   Then I should see "Word-Select-002"
-  #   #Check that the french words are not displayed
-  #   When I choose "Preview" action for "Word-Select-002" in the question bank
-  #   And I switch to "questionpreview" window
-  #   And I should see "two"
-  #   And I should not see "deaux"
-  #   And I should not see "trois"
-  #   And I should not see "correct"
+  @javascript
+  Scenario: Create a question and check (core) mlang works as expected
+    When I am on the "Course 1" "core_question > course question bank" page logged in as teacher1
+    And I add a "Word Select" question filling the form with:
+        | Question name | Word-Select-002                                                 |
+        | Introduction  | <span lang="en" class="multilang">two</span><span lang="fr" class="multilang">deaux</span>                    |
+        | Question text | [correct] <span lang="en" class="multilang">three</span><span lang="fr" class="multilang">trois</span> [word] |
+    Then I should see "Word-Select-002"
+    #Check that the french words are not displayed
+    And I am on the "Word-Select-002" "core_question > preview" page
+    And I should see "two"
+    And I should not see "deaux"
+    And I should not see "trois"
+    And I should see "correct"


### PR DESCRIPTION
Hi Marcus, 

I have made changes to fix the Behat tests, testing mlang and mlang2 filters to work with qtype_wordselect.

Changes done:
- To skip mlang2 filter test, if the respective filter is not installed.
- For the second test (Scenario: Create a question and check (core) mlang works as expected), it seems that if a site uses a child language pack, then the first span tag must be the parent language. 
https://docs.moodle.org/400/en/Multi-language_content_filter

Could you please review?

Thanks,
Anupama
