### PR TITLE
Updated to support PHP 8.2

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -1,6 +1,3 @@
-
-
-
 name: Moodle plugin CI
 on: [push, pull_request]
 
@@ -33,11 +30,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - php: '8.0'
-          #   moodle-branch: 'MOODLE_402_STABLE'
-          #   database: 'mariadb'
-          - php: '8.1'
+          - php: '8.2'
             moodle-branch: 'master'
+            database: 'pgsql'
+          - php: '8.1'
+            moodle-branch: 'MOODLE_403_STABLE'
+            database: 'mariadb'
+          - php: '8.0'
+            moodle-branch: 'MOODLE_402_STABLE'
+            database: 'pgsql'
+          - php: '7.4'
+            moodle-branch: 'MOODLE_401_STABLE'
+            database: 'mariadb'
+          - php: '7.3'
+            moodle-branch: 'MOODLE_400_STABLE'
             database: 'pgsql'
 
     steps:

--- a/question.php
+++ b/question.php
@@ -33,14 +33,18 @@ defined('MOODLE_INTERNAL') || die();
  */
 class qtype_wordselect_question extends question_graded_automatically_with_countback {
 
+    /** @var string Introductory instructions shown before the question text. */
+    public $introduction;
+
+    /** @var string The pair of characters which demarcate clickable items. E.g. '[]'. */
+    public $delimitchars;
+
     /**
-     *
      * @var number how many items clicked on are not correct answers
      */
     public $wrongresponsecount = '0.0';
 
     /**
-     *
      * @var int how many items clicked on are  correct answers
      */
     public $rightresponsecount;
@@ -52,13 +56,6 @@ class qtype_wordselect_question extends question_graded_automatically_with_count
     public $multiword = false;
 
     /**
-     * is this item selectable. Only makes
-     * sense if multiword is true
-     * @var boolean
-     */
-    public $isselectable;
-
-    /**
      * fraction to deduct for each incorrectly selected text item
      * Wrong response is multiplied by this, i.e. 2 wrong responses
      * and wordpenalty of .5 means 1 penalty, default is 1, i.e. no
@@ -67,13 +64,24 @@ class qtype_wordselect_question extends question_graded_automatically_with_count
      */
     public $wordpenalty = 1.0;
 
-    /**
-     * TODO
-     * I am not sure this is necessary
-     * @var string
-     */
-    public $questiontextsplit;
+    /** @var string Feedback for any correct response. */
+    public $correctfeedback;
+    /** @var int format of $correctfeedback. */
+    public $correctfeedbackformat;
+    /** @var string Feedback for any partially correct response. */
+    public $partiallycorrectfeedback;
+    /** @var int format of $partiallycorrectfeedback. */
+    public $partiallycorrectfeedbackformat;
+    /** @var string Feedback for any incorrect response. */
+    public $incorrectfeedback;
+    /** @var int format of $incorrectfeedback. */
+    public $incorrectfeedbackformat;
 
+    /** @var string question text with most HTML removed, used to work out what text should be selectable. */
+    protected $eligables;
+
+    /** @var wordselect_item[] the selectable items in the question text. */
+    protected $items;
     /**
      * the place number with p appended, i.e. p0 p1 etc
      * @param number $place
@@ -139,7 +147,7 @@ class qtype_wordselect_question extends question_graded_automatically_with_count
             $this->eligables = self::strip_some_tags($text);
 
             $matches = preg_split($fieldregex, $text, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-            $this->items = array();
+            $this->items = [];
             foreach ($matches as $key => $text) {
                 $item = new wordselect_item($key, $text, $this->delimitchars, $this->multiword);
                 $item->set_is_selectable($this->eligables);
@@ -551,12 +559,6 @@ class qtype_wordselect_question extends question_graded_automatically_with_count
 class wordselect_item {
 
     /**
-     * characters that delimit a word or chunk of words
-     * @var string
-     */
-    private $delimitchars;
-
-    /**
      * left delimiter
      * @var string
      */
@@ -606,9 +608,7 @@ class wordselect_item {
         $this->r = substr($delimitchars, 1, 1);
         $this->id = $id;
         $this->text = $text;
-        $this->delimitchars = $delimitchars;
         $this->multiword = $multiword;
-        $this->set_correctness();
     }
 
     /**
@@ -620,20 +620,6 @@ class wordselect_item {
         return $this->id;
     }
 
-    /**
-     * Set if the item is a correct response
-     *
-     * @return void
-     */
-    public function set_correctness () {
-        $regex = "";
-        if ($this->multiword == true) {
-            $regex = '/\\' . $this->l . '\\' . $this->l . '.*\\' . $this->r . '\\' . $this->r . '/';
-        } else {
-            $regex = '/\\' . $this->l . '.*\\' . $this->r . '/';
-        }
-        $this->correctness = preg_match($regex, $this->text);
-    }
     /**
      * Get white space after the "word" or group of words delimited
      * by double delimiting characters

--- a/questiontype.php
+++ b/questiontype.php
@@ -254,6 +254,7 @@ class qtype_wordselect extends question_type {
     protected function initialise_question_instance(question_definition $question, $questiondata) {
         parent::initialise_question_instance($question, $questiondata);
         parent::initialise_combined_feedback($question, $questiondata);
+        $question->init($questiondata->questiontext, $questiondata->options->delimitchars);
     }
 
     /**

--- a/renderer.php
+++ b/renderer.php
@@ -55,8 +55,6 @@ class qtype_wordselect_renderer extends qtype_with_combined_feedback_renderer {
         $output .= html_writer::end_div();
         $output .= html_writer::start_div('qtext');
 
-        /*initialised */
-        $question->init($question->questiontext, $question->delimitchars);
         $items = $question->get_words();
         $output .= $this->get_body($question, $options, $items, $qa);
 

--- a/tests/behat/basic_test.feature
+++ b/tests/behat/basic_test.feature
@@ -46,8 +46,8 @@ create and preview wordselect (Select correct words) questions.
         | Marks                | Show mark and max |
         | Specific feedback    | Shown             |
         | Right answer         | Shown             |
-    And I press "Update display options"
-    And I press "Start again"
+    And I press "saverestart"
+
   #User does not select any word and press button Check
     And I press "Check"
     And I should see "Please select an answer."
@@ -67,7 +67,8 @@ create and preview wordselect (Select correct words) questions.
         | Marks                | Show mark and max               |
         | Specific feedback    | Shown                           |
         | Right answer         | Shown                           |
-    And I press "Save preview options and start again"
+    And I press "saverestart"
+
   #User does not select any word and press button Check
     And I press "Check"
     And I should see "Please select an answer."
@@ -107,7 +108,7 @@ create and preview wordselect (Select correct words) questions.
         | Specific feedback    | Shown              |
         | Right answer         | Shown              |
 
-    And I press "Save preview options and start again"
+    And I press "saverestart"
     And I click on "sat" "text"
     And I click on "jumped" "text"
     And I press "Check"
@@ -116,7 +117,6 @@ create and preview wordselect (Select correct words) questions.
 
     And I press "Start again"
     And I click on "sat" "text"
-
     And I press "Check"
     And I should see "Your answer is partially correct."
     And I should see "Mark 1.00 out of 2.00"
@@ -130,8 +130,7 @@ create and preview wordselect (Select correct words) questions.
         | Specific feedback    | Shown             |
         | Right answer         | Shown             |
 
-    And I press "Save preview options and start again"
-
+    And I press "saverestart"
     And I click on "sat" "text"
     And I click on "jumped" "text"
     And I press "Submit and finish"
@@ -187,7 +186,8 @@ create and preview wordselect (Select correct words) questions.
         | Marks                | Show mark and max               |
         | Specific feedback    | Shown                           |
         | Right answer         | Shown                           |
-    And I press "Save preview options and start again"
+    And I press "saverestart"
+
   #Select all (both) correct options and  an incorrect
   #option (cow)
     And I click on "sat" "text"

--- a/tests/behat/phrase_special_test.feature
+++ b/tests/behat/phrase_special_test.feature
@@ -42,8 +42,7 @@ Feature: Test that formatting within delimiters is retained
         | Marks                | Show mark and max               |
         | Specific feedback    | Shown                           |
         | Right answer         | Shown                           |
-    And I press "Update display options"
-    And I press "Start again"
+    And I press "saverestart"
 
     #Select all (both) correct options
     And I click on "sat" "text"

--- a/tests/behat/review_d_feedback.feature
+++ b/tests/behat/review_d_feedback.feature
@@ -43,8 +43,7 @@ Feature: Test wordselect showiing of correctness with direct feedback
         | Right answer         | Shown             |
         | Whether correct      | Shown             |
 
-    And I press "Save preview options and start again"
-
+    And I press "saverestart"
     #Select all (both) correct options
     And I click on "sat" "text"
     And I click on "jumped" "text"
@@ -72,7 +71,7 @@ Feature: Test wordselect showiing of correctness with direct feedback
         | Right answer         | Not shown                       |
         | Whether correct      | Not shown                       |
 
-    And I press "Save preview options and start again"
+    And I press "saverestart"
 
     #Select two incorrect options and show which ones should have been selected
     And I click on "The" "text"

--- a/tests/behat/review_i_multiple.feature
+++ b/tests/behat/review_i_multiple.feature
@@ -45,7 +45,7 @@ Feature: Test wordselect showing of correctness with iwm question behaviour
         | Right answer         | Shown                           |
         | Whether correct      | Shown                           |
 
-    And I press "Save preview options and start again"
+    And I press "saverestart"
     #Select all (both) correct options
     And I click on "sat" "text"
     And I click on "jumped" "text"
@@ -72,7 +72,7 @@ Feature: Test wordselect showing of correctness with iwm question behaviour
         | Right answer         | Not shown                       |
         | Whether correct      | Not shown                       |
 
-    And I press "Save preview options and start again"
+    And I press "saverestart"
 
     #Select two incorrect options and show which ones should have been selected
     And I click on "The" "text"


### PR DESCRIPTION
The main changes here (third commit) are changes to stop PHP 8.2 giving deprecated warnings about undefined fields like

```
Exception: Moodle exception: Exception - Unknown error type: Creation of dynamic property qtype_wordselect_question::$correctfeedback is deprecated in [dirroot]\question\type\questiontypebase.php on line 1091 More information about this error
```

Along the way, I corrected where 'init' is called.

Also: I fixed Behat tests affecte by the change to the wording of the "Save preview options and start again" button.

And, I updated the Moodle plugin CI config to test against all the Moodle versions that the plugins DB claims are supported, and a range of PHP versions.

I hope this is useful.