### PR TITLE
Make changes needed after the fix of MDL-83541

### DIFF
--- a/backup/moodle2/restore_qtype_wordselect_plugin.class.php
+++ b/backup/moodle2/restore_qtype_wordselect_plugin.class.php
@@ -182,4 +182,15 @@ class restore_qtype_wordselect_plugin extends restore_qtype_plugin {
         $this->set_mapping('question_answer', $oldid, $newitemid);
     }
 
+    /**
+     * Return a list of paths to fields to be removed from questiondata before creating an identity hash.
+     * We have to remove the id property from all answers.
+     *
+     * @return array
+     */
+    protected function define_excluded_identity_hash_fields(): array {
+        return [
+            '/options/answers/id',
+        ];
+    }
 }


### PR DESCRIPTION
With the fix of MDL-83541, Moodle will calculate a hash of all relevant fields of a question and its answers during the restore process. This allows to avoid duplicating questions during imports while still being able to distinguish different questions with the same "stamp".

This PR makes the [necessary changes](https://moodledev.io/docs/5.0/apis/plugintypes/qtype/restore).

It can be tested using the `mod/quiz/tests/backup/repeated_restore_test.php` unit tests in Moodle 4.5 and upcoming 5.0. 

**Note**

The tests will fail until #60 is merged.