### PR TITLE
Fix unit test mod_quiz test_restore_quiz_with_duplicate_questions

### DIFF
--- a/backup/moodle2/restore_qtype_wordselect_plugin.class.php
+++ b/backup/moodle2/restore_qtype_wordselect_plugin.class.php
@@ -52,6 +52,26 @@ class restore_qtype_wordselect_plugin extends restore_qtype_plugin {
         return $paths; // And we return the interesting paths.
     }
 
+
+    /**
+     * Define excluded identity hash fields.
+     */    
+    public function define_excluded_identity_hash_fields(): array {
+        return [
+            // These option fields are present in the database, but are only used by calculatedmulti.
+            '/options/questionid',
+            '/options/introduction',
+            '/options/delimitchars',
+            '/options/wordpenalty',
+            '/options/correctfeedback',
+            '/options/correctfeedbackformat',
+            '/options/partiallycorrectfeedback',
+            '/options/partiallycorrectfeedbackformat',
+            '/options/incorrectfeedback',
+            '/options/incorrectfeedbackformat',
+        ];
+    }
+
     /**
      * Process the qtype/wordselect element
      * @param array $data


### PR DESCRIPTION
This will fix

2) mod_quiz\backup\repeated_restore_test::test_restore_quiz_with_duplicate_questions with data set "wordselect" ('wordselect', 'catmat')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'174002'
+'174003'
/builds/elearning/moodle/mod/quiz/tests/backup/repeated_restore_test.php:423
/builds/elearning/moodle/lib/phpunit/classes/advanced_testcase.php:76