### PR TITLE
qtype_wordselect: Implement regrade validation

### DIFF
--- a/lang/en/qtype_wordselect.php
+++ b/lang/en/qtype_wordselect.php
@@ -41,6 +41,7 @@ $string['pluginnamesummary'] = 'All words can be selected by clicking on them. C
 $string['privacy:null_reason'] = 'The Wordselect question type does not effect or store any data itself.';
 $string['questiontext'] = 'question text';
 $string['questiontext_help'] = 'Put square braces around the correct words ';
+$string['regradeissueselectedwordschanged'] = 'The selected words have changed.';
 $string['taptoselect'] = 'Tap to select';
 $string['wordpenalty'] = 'Incorrect selection penalty';
 $string['wordpenalty_help'] = 'Decrement mark by this percentage for each incorrectly selected word';

--- a/question.php
+++ b/question.php
@@ -364,6 +364,64 @@ class qtype_wordselect_question extends question_graded_automatically_with_count
     }
 
     /**
+     * Get the selected words used to decide if regrading between versions is safe.
+     *
+     * The order of the selected words in the question text is ignored, but duplicate
+     * selections are preserved so count changes are still detected.
+     *
+     * @return string[]
+     */
+    protected function get_selected_words_for_regrade_validation(): array {
+        $selectedwords = [];
+        $items = $this->get_words();
+
+        foreach ($this->get_correct_places($this->questiontext, $this->delimitchars) as $place) {
+            if (!array_key_exists($place, $items)) {
+                continue;
+            }
+
+            $selectedwords[] = $this->normalise_selected_word_for_regrade_validation(
+                $items[$place]->get_without_delim()
+            );
+        }
+
+        sort($selectedwords, SORT_STRING);
+
+        return $selectedwords;
+    }
+
+    /**
+     * Convert a selected word or phrase to a comparable plain-text representation.
+     *
+     * @param string $selectedword
+     * @return string
+     */
+    protected function normalise_selected_word_for_regrade_validation(string $selectedword): string {
+        $selectedword = $this->html_to_text($selectedword, FORMAT_HTML);
+        $selectedword = preg_replace('/\s+/u', ' ', $selectedword);
+
+        return trim($selectedword);
+    }
+
+    #[\Override]
+    public function validate_can_regrade_with_other_version(question_definition $otherversion): ?string {
+        $basemessage = parent::validate_can_regrade_with_other_version($otherversion);
+        if ($basemessage) {
+            return $basemessage;
+        }
+
+        $selectedwords = $this->get_selected_words_for_regrade_validation();
+        assert($otherversion instanceof qtype_wordselect_question);
+        $otherselectedwords = $otherversion->get_selected_words_for_regrade_validation();
+
+        if ($selectedwords !== $otherselectedwords) {
+            return get_string('regradeissueselectedwordschanged', 'qtype_wordselect');
+        }
+
+        return null;
+    }
+
+    /**
      * contains the a response that would get full marks.
      * used in preview mode. If this doesn't return a
      * correct value the button labeled "Fill in correct response"

--- a/tests/question_test.php
+++ b/tests/question_test.php
@@ -257,4 +257,44 @@ final class question_test extends \advanced_testcase {
         $correctplaces = ['0' => 4];
         $this->assertEquals($question->get_correct_places($question->questiontext, '[]'), $correctplaces);
     }
+
+    /**
+     * Test validate_can_regrade_with_other_version() with multiple scenarios.
+     *
+     * @dataProvider validate_can_regrade_provider
+     * @param string $oldquestiontext
+     * @param string $newquestiontext
+     * @param string|null $expectedstringkey null if regrade should be allowed, or language key for expected failure reason
+     * @covers ::validate_can_regrade_with_other_version
+     */
+    public function test_validate_can_regrade_with_other_version(
+        string $oldquestiontext,
+        string $newquestiontext,
+        ?string $expectedstringkey
+    ): void {
+        $old = helper::make_question('wordselect', $oldquestiontext);
+        $new = helper::make_question('wordselect', $newquestiontext);
+
+        $result = $new->validate_can_regrade_with_other_version($old);
+        if ($expectedstringkey === null) {
+            $this->assertNull($result);
+        } else {
+            $this->assertEquals(get_string($expectedstringkey, 'qtype_wordselect'), $result);
+        }
+    }
+
+    /**
+     * Data provider for test_validate_can_regrade_with_other_version.
+     *
+     * @return array
+     */
+    public static function validate_can_regrade_provider(): array {
+        return [
+            'allow_surrounding_text' => ['[[Pip]] jump on the bed', 'On the bed, [[Pip]] jumps', null],
+            'block_word_added' => ['The [cat] sat on the mat', 'The [cat] [sat] on the mat', 'regradeissueselectedwordschanged'],
+            'block_word_changed' => ['[[Apple]] is a fruit', 'Apple is a [[fruit]]', 'regradeissueselectedwordschanged'],
+            'block_count_changed' => ['The [cat] [sat] on the mat', 'The [cat] sat on the mat', 'regradeissueselectedwordschanged'],
+            'allow_reordered' => ['The [cat] chased the [dog]', 'The [dog] was chased by the [cat]', null],
+        ];
+    }
 }


### PR DESCRIPTION
Hi @marcusgreen ,
During testing, we found that worsselect hasn’t implemented the regrade validation logic, so we’ve added it.
Could you please review the changes?

Many thanks.